### PR TITLE
ホーム画面を作る

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,15 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:foodie_kyoto/ui/pages/home_page.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-void main() {
-  runApp(const MyApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const ProviderScope(child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {
@@ -30,7 +35,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const HomePage(),
     );
   }
 }

--- a/lib/ui/pages/google_map_page/google_map_page.dart
+++ b/lib/ui/pages/google_map_page/google_map_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class GoogleMapPage extends StatelessWidget {
+  const GoogleMapPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('This is sample google map page'),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:foodie_kyoto/ui/pages/google_map_page/google_map_page.dart';
+import 'package:foodie_kyoto/ui/pages/home_page_view_model.dart';
+import 'package:foodie_kyoto/ui/pages/list_page/list_page.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class HomePage extends HookConsumerWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final _currentIndex =
+        ref.watch(homePageViewModelProvider.select((s) => s.currentIndex));
+
+    const _pages = [
+      GoogleMapPage(),
+      ListPage(),
+    ];
+
+    return Scaffold(
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (index) {
+          ref.read(homePageViewModelProvider.notifier).onTapItems(index);
+        },
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.place_rounded), label: ''),
+          BottomNavigationBarItem(icon: Icon(Icons.list_rounded), label: ''),
+        ],
+      ),
+      body: _pages.elementAt(_currentIndex),
+    );
+  }
+}

--- a/lib/ui/pages/home_page_view_model.dart
+++ b/lib/ui/pages/home_page_view_model.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+part 'home_page_view_model.freezed.dart';
+
+final homePageViewModelProvider =
+    StateNotifierProvider.autoDispose<HomePageViewModel, HomePageState>(
+        (ref) => HomePageViewModel());
+
+@freezed
+class HomePageState with _$HomePageState {
+  factory HomePageState({
+    @Default(0) int currentIndex,
+  }) = _HomePageState;
+}
+
+class HomePageViewModel extends StateNotifier<HomePageState> {
+  HomePageViewModel() : super(HomePageState(currentIndex: 0));
+
+  void onTapItems(int index) {
+    final currentState = state;
+    state = currentState.copyWith(currentIndex: index);
+  }
+}

--- a/lib/ui/pages/home_page_view_model.freezed.dart
+++ b/lib/ui/pages/home_page_view_model.freezed.dart
@@ -1,0 +1,146 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'home_page_view_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$HomePageStateTearOff {
+  const _$HomePageStateTearOff();
+
+  _HomePageState call({int currentIndex = 0}) {
+    return _HomePageState(
+      currentIndex: currentIndex,
+    );
+  }
+}
+
+/// @nodoc
+const $HomePageState = _$HomePageStateTearOff();
+
+/// @nodoc
+mixin _$HomePageState {
+  int get currentIndex => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $HomePageStateCopyWith<HomePageState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HomePageStateCopyWith<$Res> {
+  factory $HomePageStateCopyWith(
+          HomePageState value, $Res Function(HomePageState) then) =
+      _$HomePageStateCopyWithImpl<$Res>;
+  $Res call({int currentIndex});
+}
+
+/// @nodoc
+class _$HomePageStateCopyWithImpl<$Res>
+    implements $HomePageStateCopyWith<$Res> {
+  _$HomePageStateCopyWithImpl(this._value, this._then);
+
+  final HomePageState _value;
+  // ignore: unused_field
+  final $Res Function(HomePageState) _then;
+
+  @override
+  $Res call({
+    Object? currentIndex = freezed,
+  }) {
+    return _then(_value.copyWith(
+      currentIndex: currentIndex == freezed
+          ? _value.currentIndex
+          : currentIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$HomePageStateCopyWith<$Res>
+    implements $HomePageStateCopyWith<$Res> {
+  factory _$HomePageStateCopyWith(
+          _HomePageState value, $Res Function(_HomePageState) then) =
+      __$HomePageStateCopyWithImpl<$Res>;
+  @override
+  $Res call({int currentIndex});
+}
+
+/// @nodoc
+class __$HomePageStateCopyWithImpl<$Res>
+    extends _$HomePageStateCopyWithImpl<$Res>
+    implements _$HomePageStateCopyWith<$Res> {
+  __$HomePageStateCopyWithImpl(
+      _HomePageState _value, $Res Function(_HomePageState) _then)
+      : super(_value, (v) => _then(v as _HomePageState));
+
+  @override
+  _HomePageState get _value => super._value as _HomePageState;
+
+  @override
+  $Res call({
+    Object? currentIndex = freezed,
+  }) {
+    return _then(_HomePageState(
+      currentIndex: currentIndex == freezed
+          ? _value.currentIndex
+          : currentIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_HomePageState implements _HomePageState {
+  _$_HomePageState({this.currentIndex = 0});
+
+  @JsonKey()
+  @override
+  final int currentIndex;
+
+  @override
+  String toString() {
+    return 'HomePageState(currentIndex: $currentIndex)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _HomePageState &&
+            const DeepCollectionEquality()
+                .equals(other.currentIndex, currentIndex));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(currentIndex));
+
+  @JsonKey(ignore: true)
+  @override
+  _$HomePageStateCopyWith<_HomePageState> get copyWith =>
+      __$HomePageStateCopyWithImpl<_HomePageState>(this, _$identity);
+}
+
+abstract class _HomePageState implements HomePageState {
+  factory _HomePageState({int currentIndex}) = _$_HomePageState;
+
+  @override
+  int get currentIndex;
+  @override
+  @JsonKey(ignore: true)
+  _$HomePageStateCopyWith<_HomePageState> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/ui/pages/list_page/list_page.dart
+++ b/lib/ui/pages/list_page/list_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class ListPage extends StatelessWidget {
+  const ListPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('This is sample list page'),
+      ),
+    );
+  }
+}

--- a/test/bottom_nav_bar_test.dart
+++ b/test/bottom_nav_bar_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:foodie_kyoto/ui/pages/home_page_view_model.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  late HomePageViewModel onTapItems;
+
+  setUp(() {
+    final container = ProviderContainer();
+    onTapItems = container.read(homePageViewModelProvider.notifier);
+  });
+
+  group('on tap nav bar', () {
+    test('change index', () {
+      //初期状態
+      expect(onTapItems.debugState.currentIndex, 0);
+
+      //tap list page
+      onTapItems.onTapItems(1);
+
+      //状態確認
+      expect(onTapItems.debugState.currentIndex, 1);
+
+      //tap map oage
+      onTapItems.onTapItems(0);
+
+      //状態確認
+      expect(onTapItems.debugState.currentIndex, 0);
+    });
+  });
+}


### PR DESCRIPTION
- #21 

## 仕様
- [x] 仮のgoogle mapページとlistページをボトムナビゲーションによって切り替えできる

## このissueでやらないこと
- 各ページの実装
- デザインやアイコンの作り込み

## commit説明
- https://github.com/MatsumaruTsuyoshi/foodie_kyoto/commit/846820fcf68c2d1a26b37de8beb267ec21df0d00
ルートページの変更とmain() 内に初期化処理を入れる
- https://github.com/MatsumaruTsuyoshi/foodie_kyoto/commit/3739dcb9184d9ed0a3698353989d57b0ff0657ce
google map と list ページ（中身は別タスクで実装）
- https://github.com/MatsumaruTsuyoshi/foodie_kyoto/commit/932126972fdac39c579cbf663da3a4c53d9dae6d
ホーム画面とそのview model
- https://github.com/MatsumaruTsuyoshi/foodie_kyoto/commit/b0168f6352900b2e5dee9375d5c3ca3f63e41a47
view model内にある関数のユニットテスト

## Screenshot (Opt)

google map tab | list tab
:--: | :--:
<img src="https://user-images.githubusercontent.com/87467867/160341950-7f0f2c62-826b-41e0-bbd8-b9f05b0e599a.png" width="300" /> | <img src="https://user-images.githubusercontent.com/87467867/160341962-43a27d9d-45bf-4c14-9c6e-5dc1b0f9891b.png" width="300" />
