### PR TITLE
google map ページをriver pod を使った方式に書き換える

### DIFF
--- a/lib/ui/pages/google_map_page/google_map_model.dart
+++ b/lib/ui/pages/google_map_page/google_map_model.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -15,7 +14,7 @@ class GoogleMapState with _$GoogleMapState {
 }
 
 class GoogleMapPageController extends StateNotifier<GoogleMapState> {
-  GoogleMapPageController() : super(GoogleMapState());
+  GoogleMapPageController() : super(GoogleMapState.creating());
 
   void onMapCreated(controller) async {
     state = GoogleMapState(googleMapController: controller);

--- a/lib/ui/pages/google_map_page/google_map_model.dart
+++ b/lib/ui/pages/google_map_page/google_map_model.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+part 'google_map_model.freezed.dart';
+
+@freezed
+class GoogleMapState with _$GoogleMapState {
+  factory GoogleMapState({GoogleMapController? googleMapController}) =
+      _GoogleMapState;
+
+  factory GoogleMapState.creating() = _GoogleMapStateCreating;
+}
+
+class GoogleMapPageController extends StateNotifier<GoogleMapState> {
+  GoogleMapPageController() : super(GoogleMapState());
+
+  void onMapCreated(controller) async {
+    state = GoogleMapState(googleMapController: controller);
+  }
+
+  Future<void> goToTheLake({required CameraPosition position}) async {
+    final currentState = state as _GoogleMapState;
+    if (state is _GoogleMapState) {
+      await currentState.googleMapController
+          ?.animateCamera(CameraUpdate.newCameraPosition(position));
+    }
+  }
+}

--- a/lib/ui/pages/google_map_page/google_map_model.freezed.dart
+++ b/lib/ui/pages/google_map_page/google_map_model.freezed.dart
@@ -1,0 +1,333 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'google_map_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$GoogleMapStateTearOff {
+  const _$GoogleMapStateTearOff();
+
+  _GoogleMapState call({GoogleMapController? googleMapController}) {
+    return _GoogleMapState(
+      googleMapController: googleMapController,
+    );
+  }
+
+  _GoogleMapStateCreating creating() {
+    return _GoogleMapStateCreating();
+  }
+}
+
+/// @nodoc
+const $GoogleMapState = _$GoogleMapStateTearOff();
+
+/// @nodoc
+mixin _$GoogleMapState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(GoogleMapController? googleMapController) $default, {
+    required TResult Function() creating,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult Function(GoogleMapController? googleMapController)? $default, {
+    TResult Function()? creating,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(GoogleMapController? googleMapController)? $default, {
+    TResult Function()? creating,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_GoogleMapState value) $default, {
+    required TResult Function(_GoogleMapStateCreating value) creating,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult Function(_GoogleMapState value)? $default, {
+    TResult Function(_GoogleMapStateCreating value)? creating,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_GoogleMapState value)? $default, {
+    TResult Function(_GoogleMapStateCreating value)? creating,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GoogleMapStateCopyWith<$Res> {
+  factory $GoogleMapStateCopyWith(
+          GoogleMapState value, $Res Function(GoogleMapState) then) =
+      _$GoogleMapStateCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$GoogleMapStateCopyWithImpl<$Res>
+    implements $GoogleMapStateCopyWith<$Res> {
+  _$GoogleMapStateCopyWithImpl(this._value, this._then);
+
+  final GoogleMapState _value;
+  // ignore: unused_field
+  final $Res Function(GoogleMapState) _then;
+}
+
+/// @nodoc
+abstract class _$GoogleMapStateCopyWith<$Res> {
+  factory _$GoogleMapStateCopyWith(
+          _GoogleMapState value, $Res Function(_GoogleMapState) then) =
+      __$GoogleMapStateCopyWithImpl<$Res>;
+  $Res call({GoogleMapController? googleMapController});
+}
+
+/// @nodoc
+class __$GoogleMapStateCopyWithImpl<$Res>
+    extends _$GoogleMapStateCopyWithImpl<$Res>
+    implements _$GoogleMapStateCopyWith<$Res> {
+  __$GoogleMapStateCopyWithImpl(
+      _GoogleMapState _value, $Res Function(_GoogleMapState) _then)
+      : super(_value, (v) => _then(v as _GoogleMapState));
+
+  @override
+  _GoogleMapState get _value => super._value as _GoogleMapState;
+
+  @override
+  $Res call({
+    Object? googleMapController = freezed,
+  }) {
+    return _then(_GoogleMapState(
+      googleMapController: googleMapController == freezed
+          ? _value.googleMapController
+          : googleMapController // ignore: cast_nullable_to_non_nullable
+              as GoogleMapController?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_GoogleMapState implements _GoogleMapState {
+  _$_GoogleMapState({this.googleMapController});
+
+  @override
+  final GoogleMapController? googleMapController;
+
+  @override
+  String toString() {
+    return 'GoogleMapState(googleMapController: $googleMapController)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _GoogleMapState &&
+            const DeepCollectionEquality()
+                .equals(other.googleMapController, googleMapController));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(googleMapController));
+
+  @JsonKey(ignore: true)
+  @override
+  _$GoogleMapStateCopyWith<_GoogleMapState> get copyWith =>
+      __$GoogleMapStateCopyWithImpl<_GoogleMapState>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(GoogleMapController? googleMapController) $default, {
+    required TResult Function() creating,
+  }) {
+    return $default(googleMapController);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult Function(GoogleMapController? googleMapController)? $default, {
+    TResult Function()? creating,
+  }) {
+    return $default?.call(googleMapController);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(GoogleMapController? googleMapController)? $default, {
+    TResult Function()? creating,
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(googleMapController);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_GoogleMapState value) $default, {
+    required TResult Function(_GoogleMapStateCreating value) creating,
+  }) {
+    return $default(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult Function(_GoogleMapState value)? $default, {
+    TResult Function(_GoogleMapStateCreating value)? creating,
+  }) {
+    return $default?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_GoogleMapState value)? $default, {
+    TResult Function(_GoogleMapStateCreating value)? creating,
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _GoogleMapState implements GoogleMapState {
+  factory _GoogleMapState({GoogleMapController? googleMapController}) =
+      _$_GoogleMapState;
+
+  GoogleMapController? get googleMapController;
+  @JsonKey(ignore: true)
+  _$GoogleMapStateCopyWith<_GoogleMapState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$GoogleMapStateCreatingCopyWith<$Res> {
+  factory _$GoogleMapStateCreatingCopyWith(_GoogleMapStateCreating value,
+          $Res Function(_GoogleMapStateCreating) then) =
+      __$GoogleMapStateCreatingCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$GoogleMapStateCreatingCopyWithImpl<$Res>
+    extends _$GoogleMapStateCopyWithImpl<$Res>
+    implements _$GoogleMapStateCreatingCopyWith<$Res> {
+  __$GoogleMapStateCreatingCopyWithImpl(_GoogleMapStateCreating _value,
+      $Res Function(_GoogleMapStateCreating) _then)
+      : super(_value, (v) => _then(v as _GoogleMapStateCreating));
+
+  @override
+  _GoogleMapStateCreating get _value => super._value as _GoogleMapStateCreating;
+}
+
+/// @nodoc
+
+class _$_GoogleMapStateCreating implements _GoogleMapStateCreating {
+  _$_GoogleMapStateCreating();
+
+  @override
+  String toString() {
+    return 'GoogleMapState.creating()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _GoogleMapStateCreating);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(GoogleMapController? googleMapController) $default, {
+    required TResult Function() creating,
+  }) {
+    return creating();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult Function(GoogleMapController? googleMapController)? $default, {
+    TResult Function()? creating,
+  }) {
+    return creating?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(GoogleMapController? googleMapController)? $default, {
+    TResult Function()? creating,
+    required TResult orElse(),
+  }) {
+    if (creating != null) {
+      return creating();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_GoogleMapState value) $default, {
+    required TResult Function(_GoogleMapStateCreating value) creating,
+  }) {
+    return creating(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult Function(_GoogleMapState value)? $default, {
+    TResult Function(_GoogleMapStateCreating value)? creating,
+  }) {
+    return creating?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_GoogleMapState value)? $default, {
+    TResult Function(_GoogleMapStateCreating value)? creating,
+    required TResult orElse(),
+  }) {
+    if (creating != null) {
+      return creating(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _GoogleMapStateCreating implements GoogleMapState {
+  factory _GoogleMapStateCreating() = _$_GoogleMapStateCreating;
+}

--- a/lib/ui/pages/google_map_page/google_map_page.dart
+++ b/lib/ui/pages/google_map_page/google_map_page.dart
@@ -1,17 +1,10 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
+import 'package:foodie_kyoto/ui/pages/google_map_page/google_map_provider.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class GoogleMapPage extends StatefulWidget {
+class GoogleMapPage extends HookConsumerWidget {
   const GoogleMapPage({Key? key}) : super(key: key);
-
-  @override
-  State<GoogleMapPage> createState() => _GoogleMapPageState();
-}
-
-class _GoogleMapPageState extends State<GoogleMapPage> {
-  final Completer<GoogleMapController> _controller = Completer();
 
   static const CameraPosition _kGooglePlex = CameraPosition(
     target: LatLng(37.42796133580664, -122.085749655962),
@@ -25,25 +18,26 @@ class _GoogleMapPageState extends State<GoogleMapPage> {
       zoom: 19.151926040649414);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(googleMapProvider);
+
     return Scaffold(
       body: GoogleMap(
         mapType: MapType.normal,
         initialCameraPosition: _kGooglePlex,
         onMapCreated: (GoogleMapController controller) {
-          _controller.complete(controller);
+          ref.read(googleMapProvider.notifier).onMapCreated(controller);
         },
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: _goToTheLake,
-        label: const Text('To the lake!'),
-        icon: const Icon(Icons.directions_boat),
-      ),
+      floatingActionButton: state.when(
+          (googleMapController) => FloatingActionButton.extended(
+                onPressed: () => ref
+                    .read(googleMapProvider.notifier)
+                    .goToTheLake(position: _kLake),
+                label: const Text('To the lake!'),
+                icon: const Icon(Icons.directions_boat),
+              ),
+          creating: () => const SizedBox()),
     );
-  }
-
-  Future<void> _goToTheLake() async {
-    final GoogleMapController controller = await _controller.future;
-    controller.animateCamera(CameraUpdate.newCameraPosition(_kLake));
   }
 }

--- a/lib/ui/pages/google_map_page/google_map_page.dart
+++ b/lib/ui/pages/google_map_page/google_map_page.dart
@@ -25,9 +25,7 @@ class GoogleMapPage extends HookConsumerWidget {
       body: GoogleMap(
         mapType: MapType.normal,
         initialCameraPosition: _kGooglePlex,
-        onMapCreated: (GoogleMapController controller) {
-          ref.read(googleMapProvider.notifier).onMapCreated(controller);
-        },
+        onMapCreated: ref.read(googleMapProvider.notifier).onMapCreated,
       ),
       floatingActionButton: state.when(
           (googleMapController) => FloatingActionButton.extended(

--- a/lib/ui/pages/google_map_page/google_map_provider.dart
+++ b/lib/ui/pages/google_map_page/google_map_provider.dart
@@ -1,0 +1,6 @@
+import 'package:foodie_kyoto/ui/pages/google_map_page/google_map_model.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final googleMapProvider =
+    StateNotifierProvider<GoogleMapPageController, GoogleMapState>(
+        (ref) => GoogleMapPageController());


### PR DESCRIPTION
- #28 

### 実装済み項目
- mapコントローラ初期化
- goToLakeメソッドの書き換え
（変更前の状態と等価）

### 未実装
テスト。
現状はとりあえずデモページと同じ状態にしていて、のちに削除する予定なので不要かなと
仕様通りのものだけ書いていこう。